### PR TITLE
feat: implement bot and api gateway services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# tasker
+# Tasker
+
+Minimal microservice architecture featuring an API gateway and a Telegram bot
+service.  The services use a tiny in-repository stub of FastAPI so that the
+codebase can be executed and tested without external dependencies.
+
+## Setup and Testing
+
+1. Ensure a recent version of **Python (3.11+)** is available.
+2. Clone the repository and optionally create a virtual environment:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+3. The repo vendors small stubs of both **FastAPI** and the
+   ``python-telegram-bot`` library, so no extra packages are required for local
+   tests.  To verify everything works run:
+
+   ```bash
+   pytest
+   ```
+   All tests should pass.
+
+## Services
+
+- **api-gateway** – single entry point that forwards requests to internal
+  services using round-robin load balancing.
+- **bot** – Telegram webhook handler supporting `/ping` and `/who` commands and
+  demonstrating Telegram menu configuration.
+
+## Development
+
+The repository contains unit tests for both services.  To run them simply
+execute:
+
+```bash
+pytest
+```
+
+## Running with Docker
+
+`docker-compose.yml` describes how the services could be containerised.  Building
+these images requires an Internet connection to install the real FastAPI
+package.  Launch the stack with:
+
+```bash
+docker-compose up --build
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+
+services:
+  api-gateway:
+    build: ./services/api_gateway
+    ports:
+      - "8080:8000"
+    depends_on:
+      - bot
+
+  bot:
+    build: ./services/bot

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -1,0 +1,69 @@
+"""A tiny stub of the :mod:`fastapi` package used for offline tests.
+
+This module provides a minimal subset of FastAPI's interface so that the
+example services can be exercised without installing external dependencies.
+It supports registering synchronous GET and POST routes and exposes a
+``FastAPI`` application object with a :py:meth:`handle_request` method used by
+unit tests and the API gateway.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+
+class HTTPException(Exception):
+    """Lightweight HTTP exception carrying a status code and detail message."""
+
+    def __init__(self, status_code: int, detail: str) -> None:
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+class FastAPI:
+    """Very small web framework inspired by FastAPI.
+
+    Only the features required for the unit tests are implemented:
+
+    * Route registration via :py:meth:`get` and :py:meth:`post` decorators.
+    * A :py:meth:`handle_request` helper that dispatches a request to the
+      registered handler and returns ``(status_code, payload)``.
+    """
+
+    def __init__(self) -> None:
+        self._routes: Dict[str, Dict[str, Callable[[Any], Any]]] = {
+            "GET": {},
+            "POST": {},
+        }
+
+    def get(self, path: str) -> Callable[[Callable[[Any], Any]], Callable[[Any], Any]]:
+        """Register a synchronous GET endpoint."""
+        def decorator(func: Callable[[Any], Any]) -> Callable[[Any], Any]:
+            self._routes["GET"][path] = func
+            return func
+        return decorator
+
+    def post(self, path: str) -> Callable[[Callable[[Any], Any]], Callable[[Any], Any]]:
+        """Register a synchronous POST endpoint."""
+        def decorator(func: Callable[[Any], Any]) -> Callable[[Any], Any]:
+            self._routes["POST"][path] = func
+            return func
+        return decorator
+
+    def handle_request(self, method: str, path: str, json: Any = None) -> Tuple[int, Any]:
+        """Dispatch the request to the registered handler.
+
+        Parameters
+        ----------
+        method:
+            HTTP verb in upper case (e.g. ``"GET"`` or ``"POST"``).
+        path:
+            Request path starting with ``/``.
+        json:
+            Parsed JSON payload supplied for POST requests.
+        """
+        handler = self._routes.get(method, {}).get(path)
+        if handler is None:
+            return 404, {"detail": "Not Found"}
+        if json is None:
+            return 200, handler()
+        return 200, handler(json)
+
+__all__ = ["FastAPI", "HTTPException"]

--- a/fastapi/testclient.py
+++ b/fastapi/testclient.py
@@ -1,0 +1,28 @@
+"""Testing helpers for the :mod:`fastapi` stub.
+
+The real FastAPI library ships with a starlette-based ``TestClient`` that
+spins up the ASGI application.  For the purposes of these exercises we simply
+call :py:meth:`fastapi.FastAPI.handle_request` directly.
+"""
+
+from typing import Any
+from . import FastAPI
+
+class Response:
+    """Minimal response object mimicking ``requests.Response``."""
+    def __init__(self, status_code: int, data: Any) -> None:
+        self.status_code = status_code
+        self._data = data
+    def json(self) -> Any:
+        return self._data
+
+class TestClient:
+    """Synchronous test client for the stubbed :class:`FastAPI` apps."""
+    def __init__(self, app: FastAPI) -> None:
+        self.app = app
+    def get(self, path: str) -> Response:
+        status, data = self.app.handle_request("GET", path)
+        return Response(status, data)
+    def post(self, path: str, json: Any = None) -> Response:
+        status, data = self.app.handle_request("POST", path, json)
+        return Response(status, data)

--- a/services/api_gateway/Dockerfile
+++ b/services/api_gateway/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/api_gateway/main.py
+++ b/services/api_gateway/main.py
@@ -1,0 +1,75 @@
+"""API Gateway service.
+
+The gateway exposes a single HTTP interface and forwards requests to
+registered backend services using a simple round-robin strategy.
+It relies on the minimal ``fastapi`` stub shipped with the repository and
+is intentionally synchronous and lightweight so it can run in restricted
+environments such as this kata.
+"""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from typing import Callable, Dict, List, Tuple, Any
+
+class RoundRobin:
+    """Cycle through a list of backend handlers."""
+    def __init__(self, items: List[Callable[[str, str, Any], Tuple[int, Any]]]):
+        self.items = items
+        self.index = 0
+    def next(self) -> Callable[[str, str, Any], Tuple[int, Any]]:
+        handler = self.items[self.index]
+        self.index = (self.index + 1) % len(self.items)
+        return handler
+
+class APIGateway:
+    """Registry and dispatcher for backend services."""
+    def __init__(self) -> None:
+        self.backends: Dict[str, RoundRobin] = {}
+    def register(self, name: str, apps: List[FastAPI]) -> None:
+        """Register FastAPI applications as backends for ``name``.
+
+        The gateway works with both the tiny in-repo FastAPI stub and the real
+        framework.  If a backend application exposes ``handle_request`` (the
+        stubbed API) it is used directly.  Otherwise the service falls back to
+        ``TestClient`` which is compatible with the real FastAPI package.
+        """
+        handlers: List[Callable[[str, str, Any], Tuple[int, Any]]] = []
+        for app in apps:
+            if hasattr(app, "handle_request"):
+                handlers.append(app.handle_request)
+                continue
+            client = TestClient(app)
+
+            def _call(method: str, path: str, payload: Any = None, *, _c=client) -> Tuple[int, Any]:
+                if method == "GET":
+                    resp = _c.get(path)
+                else:
+                    resp = _c.post(path, json=payload)
+                return resp.status_code, resp.json()
+
+            handlers.append(_call)
+        self.backends[name] = RoundRobin(handlers)
+    def forward(self, name: str, method: str, path: str, payload: Any = None) -> Tuple[int, Any]:
+        """Forward a request to the next backend registered for ``name``."""
+        backend = self.backends[name].next()
+        return backend(method, path, payload)
+
+gateway = APIGateway()
+app = FastAPI()
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    """Health check endpoint used by tests and monitoring."""
+    return {"status": "ok"}
+
+@app.post("/bot/webhook")
+def bot_webhook(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Proxy Telegram updates to the bot service.
+
+    The gateway determines which backend to use based on a round-robin
+    iterator.  Backends must be registered with :func:`gateway.register`
+    before handling requests.
+    """
+    status, data = gateway.forward("bot", "POST", "/webhook", payload)
+    # ``status`` is ignored because the example services always return 200
+    return data

--- a/services/api_gateway/requirements.txt
+++ b/services/api_gateway/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+httpx

--- a/services/api_gateway/tests/test_gateway.py
+++ b/services/api_gateway/tests/test_gateway.py
@@ -1,0 +1,29 @@
+import importlib.util
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+SERVICE_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.extend([str(ROOT), str(SERVICE_DIR)])
+
+from fastapi.testclient import TestClient
+from main import app, gateway
+
+# Dynamically load the bot service so we can create multiple instances
+spec = importlib.util.spec_from_file_location("bot_main", ROOT / "services" / "bot" / "main.py")
+bot_main = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bot_main)
+
+# Register two bot backends with distinct names to verify round-robin behaviour
+bot_a = bot_main.create_app("A")
+bot_b = bot_main.create_app("B")
+gateway.register("bot", [bot_a, bot_b])
+
+client = TestClient(app)
+
+def test_round_robin_forwarding():
+    first = client.post("/bot/webhook", json={"message": {"text": "/who"}})
+    second = client.post("/bot/webhook", json={"message": {"text": "/who"}})
+    assert first.status_code == second.status_code == 200
+    assert first.json()["reply"] == "A"
+    assert second.json()["reply"] == "B"

--- a/services/bot/Dockerfile
+++ b/services/bot/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -1,0 +1,78 @@
+"""Telegram bot service used in the microservice example.
+
+The real project would expose a Telegram webhook and route messages to
+other services.  For the purposes of this kata the service implements a
+small subset of the behaviour so that it can be unit tested without any
+external dependencies.
+"""
+
+from fastapi import FastAPI
+from typing import Dict, List
+
+from telegram import Bot, BotCommand
+
+
+def configure_bot_menu(bot: Bot) -> None:
+    """Register the commands shown in the Telegram UI.
+
+    The stub ``Bot`` simply stores the commands, allowing tests to verify
+    that the bot would expose the expected menu in a real environment.
+    """
+
+    commands: List[BotCommand] = [
+        BotCommand("ping", "Health check"),
+        BotCommand("who", "Identify bot instance"),
+    ]
+    bot.set_my_commands(commands)
+
+
+def create_app(bot_name: str = "bot", bot_username: str | None = None) -> FastAPI:
+    """Create and configure a bot service instance.
+
+    Parameters
+    ----------
+    bot_name:
+        Human readable name of the bot, returned by the ``/who`` command.
+    bot_username:
+        Optional username used to match commands in group chats
+        (``/ping@mybot``).
+    """
+    app = FastAPI()
+
+    @app.get("/")
+    def root() -> Dict[str, str]:
+        """Health check endpoint used by tests and monitoring."""
+        return {"status": "ok"}
+
+    @app.post("/webhook")
+    def telegram_webhook(update: Dict) -> Dict[str, str]:
+        """Handle incoming Telegram updates.
+
+        The handler understands two simple commands:
+
+        ``/ping``
+            Responds with ``{"reply": "pong"}``.
+        ``/who``
+            Returns the name of the bot instance which is useful for verifying
+            load balancing behaviour through the API gateway.
+        """
+        text = update.get("message", {}).get("text", "")
+        command = text.split()[0]
+
+        valid_pings = {"/ping"}
+        valid_whos = {"/who"}
+        if bot_username:
+            valid_pings.add(f"/ping@{bot_username}")
+            valid_whos.add(f"/who@{bot_username}")
+
+        if command in valid_pings:
+            return {"reply": "pong"}
+        if command in valid_whos:
+            return {"reply": bot_name}
+        return {"reply": "unknown"}
+
+    return app
+
+
+# The default application used when running ``python main.py``.
+app = create_app()

--- a/services/bot/requirements.txt
+++ b/services/bot/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+httpx
+python-telegram-bot

--- a/services/bot/tests/test_bot.py
+++ b/services/bot/tests/test_bot.py
@@ -1,0 +1,47 @@
+import importlib.util
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+module_path = ROOT / "services" / "bot" / "main.py"
+# Ensure the repository root is on sys.path so the fastapi stub can be imported
+sys.path.append(str(ROOT))
+
+spec = importlib.util.spec_from_file_location("bot_main", module_path)
+bot_main = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bot_main)
+
+from fastapi.testclient import TestClient
+from telegram import Bot, BotCommand
+client = TestClient(bot_main.app)
+
+def test_root_health():
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+def test_ping_command():
+    resp = client.post("/webhook", json={"message": {"text": "/ping"}})
+    assert resp.status_code == 200
+    assert resp.json()["reply"] == "pong"
+
+
+def test_ping_command_in_group_chat():
+    """Commands with ``@botname`` should be recognised in group chats."""
+    app = bot_main.create_app(bot_username="testbot")
+    local_client = TestClient(app)
+    resp = local_client.post(
+        "/webhook",
+        json={"message": {"text": "/ping@testbot", "chat": {"id": 1, "type": "group"}}},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["reply"] == "pong"
+
+
+def test_configure_bot_menu_registers_commands():
+    bot = Bot("dummy-token")
+    bot_main.configure_bot_menu(bot)
+    assert bot.commands == [
+        BotCommand("ping", "Health check"),
+        BotCommand("who", "Identify bot instance"),
+    ]

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -1,0 +1,30 @@
+"""Minimal stub of the python-telegram-bot package used for testing.
+
+Only the parts required by the unit tests are implemented.
+"""
+from dataclasses import dataclass
+from typing import List, Tuple
+
+
+@dataclass
+class BotCommand:
+    """Represents a Telegram bot command and its description."""
+    command: str
+    description: str
+
+
+class Bot:
+    """Very small subset of the ``python-telegram-bot`` Bot API."""
+
+    def __init__(self, token: str):
+        self.token = token
+        self.commands: List[BotCommand] = []
+        self.sent_messages: List[Tuple[int, str]] = []
+
+    def set_my_commands(self, commands: List[BotCommand]) -> None:
+        """Store the list of supported commands for later inspection."""
+        self.commands = commands
+
+    def send_message(self, chat_id: int, text: str) -> None:
+        """Record outgoing messages without performing network IO."""
+        self.sent_messages.append((chat_id, text))


### PR DESCRIPTION
## Summary
- document basic setup and testing flow for contributors
- make API gateway compatible with both stubbed and real FastAPI apps
- exercise Telegram bot through menu configuration and group chat commands

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4520e6c1c8320bfe15cfcb9339275